### PR TITLE
feat(scene-object) add implementation of 3d objects in scene

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,11 +6,18 @@ set(CMAKE_CXX_STANDARD 17)
 # Prevent GLFW from using Wayland
 set(GLFW_BUILD_WAYLAND OFF)
 
-# Enable warnings
+# Enable warnings for our code only, not dependencies
 if(MSVC)
     add_compile_options(/W4)
 else()
     add_compile_options(-Wall -Wextra -pedantic)
+    # Don't treat warnings as errors for external dependencies
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        add_compile_options(-Wno-error=deprecated-copy)
+    endif()
+    if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+        add_compile_options(-Wno-error=implicit-fallthrough)
+    endif()
 endif()
 
 include(FetchContent)
@@ -43,13 +50,26 @@ FetchContent_MakeAvailable(imgui)
 FetchContent_Declare(
   assimp
   GIT_REPOSITORY https://github.com/assimp/assimp.git
-  GIT_TAG        v5.4.3
+  GIT_TAG        v5.3.1  # Use a more stable version
 )
 set(ASSIMP_BUILD_TESTS OFF)
 set(ASSIMP_BUILD_ASSIMP_TOOLS OFF)
 set(ASSIMP_BUILD_SAMPLES OFF)
 set(ASSIMP_INSTALL OFF)
+set(ASSIMP_WARNINGS_AS_ERRORS OFF)  # Disable warnings as errors for Assimp
 FetchContent_MakeAvailable(assimp)
+
+# Apply platform-specific fixes for Assimp compilation issues
+if(TARGET assimp)
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        # Fix macOS deprecated-copy warnings
+        target_compile_options(assimp PRIVATE -Wno-deprecated-copy)
+    endif()
+    if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+        # Fix Linux implicit-fallthrough warnings
+        target_compile_options(assimp PRIVATE -Wno-implicit-fallthrough)
+    endif()
+endif()
 
 # Gather all source files from Engine and Editor (recursively, all .cpp and .h)
 file(GLOB_RECURSE VOLTRAY_SRC CONFIGURE_DEPENDS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,18 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(imgui)
 
+# Assimp (for mesh loading)
+FetchContent_Declare(
+  assimp
+  GIT_REPOSITORY https://github.com/assimp/assimp.git
+  GIT_TAG        v5.4.3
+)
+set(ASSIMP_BUILD_TESTS OFF)
+set(ASSIMP_BUILD_ASSIMP_TOOLS OFF)
+set(ASSIMP_BUILD_SAMPLES OFF)
+set(ASSIMP_INSTALL OFF)
+FetchContent_MakeAvailable(assimp)
+
 # Gather all source files from Engine and Editor (recursively, all .cpp and .h)
 file(GLOB_RECURSE VOLTRAY_SRC CONFIGURE_DEPENDS
     "${CMAKE_SOURCE_DIR}/Engine/*.cpp"
@@ -69,7 +81,7 @@ add_executable(Voltray ${VOLTRAY_SRC} ${IMGUI_SOURCES} ${CMAKE_SOURCE_DIR}/Vendo
 find_package(OpenGL REQUIRED)
 
 # Link GLFW and OpenGL to the Voltray executable
-target_link_libraries(Voltray PRIVATE glfw OpenGL::GL)
+target_link_libraries(Voltray PRIVATE glfw OpenGL::GL assimp)
 
 # Collect all header directories from Engine and Editor recursively
 file(GLOB_RECURSE ENGINE_HEADERS "${CMAKE_SOURCE_DIR}/Engine/*.h")
@@ -82,12 +94,13 @@ foreach(header ${ENGINE_HEADERS} ${EDITOR_HEADERS})
 endforeach()
 list(REMOVE_DUPLICATES ALL_HEADER_DIRS)
 
-# Add ImGui, glad, glfw, and root Engine/Editor include dirs
+# Add ImGui, glad, glfw, assimp, and root Engine/Editor include dirs
 list(APPEND ALL_HEADER_DIRS
     ${CMAKE_SOURCE_DIR}/Vendor/glad/include
     ${glfw_SOURCE_DIR}/include
     ${IMGUI_DIR}
     ${IMGUI_BACKEND_DIR}
+    ${assimp_SOURCE_DIR}/include
     ${CMAKE_SOURCE_DIR}/Engine
     ${CMAKE_SOURCE_DIR}/Editor
 )

--- a/Editor/Components/Viewport.cpp
+++ b/Editor/Components/Viewport.cpp
@@ -2,6 +2,7 @@
 #include <imgui.h>
 #include <filesystem>
 #include <memory>
+#include <iostream>
 
 #include "Viewport.h"
 #include "../../Engine/Graphics/Renderer.h"
@@ -103,15 +104,34 @@ namespace Editor::Components
         // Add a sphere to the right
         auto sphere = SceneObjectFactory::CreateSphere("DemoSphere", 0.8f);
         sphere->GetTransform().SetPosition(Vec3(3.0f, 0.0f, 0.0f));
-        m_Scene->AddObject(sphere);
-
-        // Add a plane as ground
+        m_Scene->AddObject(sphere); // Add a plane as ground
         auto ground = SceneObjectFactory::CreatePlane("Ground", 10.0f, 10.0f);
         ground->GetTransform().SetPosition(Vec3(0.0f, -2.0f, 0.0f));
         m_Scene->AddObject(ground);
 
-        // Load shaders
+        // pyramid model loading
         auto root = std::filesystem::current_path();
+        while (!std::filesystem::exists(root / "Models") && root.has_parent_path())
+            root = root.parent_path();
+        auto modelPath = root / "Models" / "pyramid.obj";
+
+        if (std::filesystem::exists(modelPath))
+        {
+            auto pyramid = SceneObjectFactory::LoadFromFile(modelPath.string(), "Testpyramid");
+            if (pyramid)
+            {
+                pyramid->GetTransform().SetPosition(Vec3(-3.0f, 1.0f, 0.0f));
+                m_Scene->AddObject(pyramid);
+                std::cout << "Successfully loaded pyramid.obj!" << std::endl;
+            }
+        }
+        else
+        {
+            std::cout << "pyramid.obj not found at: " << modelPath << std::endl;
+        }
+
+        // Load shaders
+        root = std::filesystem::current_path();
         while (!std::filesystem::exists(root / "Shaders") && root.has_parent_path())
             root = root.parent_path();
         auto sd = root / "Shaders";

--- a/Editor/Components/Viewport.cpp
+++ b/Editor/Components/Viewport.cpp
@@ -1,4 +1,3 @@
-// Make sure glad/gl.h is included before any OpenGL/GLFW/ImGui headers
 #include <glad/gl.h>
 #include <imgui.h>
 #include <filesystem>
@@ -9,6 +8,8 @@
 #include "../../Engine/Graphics/Mesh.h"
 #include "../../Engine/Graphics/Shader.h"
 #include "../../Engine/Graphics/Camera.h"
+#include "../../Engine/Scene/Scene.h"
+#include "../../Engine/Scene/SceneObjectFactory.h"
 #include "../../Engine/Input/Input.h"
 
 namespace Editor::Components
@@ -32,11 +33,9 @@ namespace Editor::Components
         // Set to zero to prevent double-deletion
         m_FBO = 0;
         m_ColorTex = 0;
-        m_DepthRbo = 0;
-
-        // Destroy scene objects in reverse order of creation
+        m_DepthRbo = 0; // Destroy scene objects in reverse order of creation
         // explicitly release unique_ptrs to control destruction order
-        m_Mesh.reset();
+        m_Scene.reset();
         m_Shader.reset();
         m_SkyboxShader.reset();
         m_Renderer.reset();
@@ -91,23 +90,32 @@ namespace Editor::Components
 
         glBindFramebuffer(GL_FRAMEBUFFER, 0);
     }
-
     void Viewport::initScene()
     {
-        // Create triangle mesh
-        static float verts[] = {
-            -0.5f, -0.5f, 0.0f,
-            0.5f, -0.5f, 0.0f,
-            0.0f, 0.75f, 0.0f};
-        static unsigned int inds[] = {0, 1, 2};
-        m_Mesh = std::make_unique<Mesh>(verts, sizeof(verts), inds, 3);
+        // Create scene and add some demo objects
+        m_Scene = std::make_unique<Scene>();
+
+        // Add a cube at the origin
+        auto cube = SceneObjectFactory::CreateCube("DemoCube", 1.0f);
+        cube->GetTransform().SetPosition(Vec3(0.0f, 0.0f, 0.0f));
+        m_Scene->AddObject(cube);
+
+        // Add a sphere to the right
+        auto sphere = SceneObjectFactory::CreateSphere("DemoSphere", 0.8f);
+        sphere->GetTransform().SetPosition(Vec3(3.0f, 0.0f, 0.0f));
+        m_Scene->AddObject(sphere);
+
+        // Add a plane as ground
+        auto ground = SceneObjectFactory::CreatePlane("Ground", 10.0f, 10.0f);
+        ground->GetTransform().SetPosition(Vec3(0.0f, -2.0f, 0.0f));
+        m_Scene->AddObject(ground);
 
         // Load shaders
         auto root = std::filesystem::current_path();
         while (!std::filesystem::exists(root / "Shaders") && root.has_parent_path())
             root = root.parent_path();
         auto sd = root / "Shaders";
-        m_Shader = std::make_unique<Shader>((sd / "simple.vert").string(), (sd / "simple.frag").string());
+        m_Shader = std::make_unique<Shader>((sd / "default.vert").string(), (sd / "default.frag").string());
         m_SkyboxShader = std::make_unique<Shader>((sd / "skybox.vert").string(), (sd / "skybox.frag").string());
 
         m_Renderer = std::make_unique<Renderer>();
@@ -136,12 +144,20 @@ namespace Editor::Components
         m_SkyboxShader->SetUniformMat4("u_InverseViewProj", invVP.data);
         glDrawArrays(GL_TRIANGLES, 0, 3);
         glDepthMask(GL_TRUE);
-        glClear(GL_DEPTH_BUFFER_BIT);
+        glClear(GL_DEPTH_BUFFER_BIT); // Update and render scene
+        if (m_Scene)
+        {
+            m_Scene->Update(0.016f); // Assume ~60 FPS for demo
+        }
 
-        // Mesh
+        // Mesh rendering
         m_Shader->Bind();
         m_Shader->SetUniformMat4("u_ViewProjection", m_Camera->GetViewProjectionMatrix().data);
-        m_Renderer->Draw(*m_Mesh, *m_Shader);
+
+        if (m_Scene)
+        {
+            m_Scene->Render(*m_Renderer, *m_Camera, *m_Shader);
+        }
 
         glBindFramebuffer(GL_FRAMEBUFFER, 0);
     }

--- a/Editor/Components/Viewport.h
+++ b/Editor/Components/Viewport.h
@@ -12,10 +12,11 @@
 #include <memory>
 
 #include "../UI/Panel.h"
-#include "Renderer.h"
-#include "Mesh.h"
-#include "Shader.h"
-#include "Camera.h"
+#include "../../Engine/Graphics/Renderer.h"
+#include "../../Engine/Graphics/Mesh.h"
+#include "../../Engine/Graphics/Shader.h"
+#include "../../Engine/Graphics/Camera.h"
+#include "../../Engine/Scene/Scene.h"
 
 namespace Editor::Components
 {
@@ -62,11 +63,9 @@ namespace Editor::Components
         GLuint m_ColorTex = 0;
         GLuint m_DepthRbo = 0;
         int m_FBOWidth = 0;
-        int m_FBOHeight = 0;
-
-        // Scene objects
+        int m_FBOHeight = 0; // Scene objects
         std::unique_ptr<Renderer> m_Renderer;
-        std::unique_ptr<Mesh> m_Mesh;
+        std::unique_ptr<Scene> m_Scene;
         std::unique_ptr<Shader> m_Shader;
         std::unique_ptr<Shader> m_SkyboxShader;
         std::unique_ptr<Camera> m_Camera;

--- a/Engine/Graphics/Mesh.cpp
+++ b/Engine/Graphics/Mesh.cpp
@@ -8,6 +8,28 @@ Mesh::Mesh(float *vertices, unsigned int vSize, unsigned int *indices, unsigned 
     m_IBO.Bind();
     m_VAO.AddVertexAttribute(0, 3, GL_FLOAT, GL_FALSE, 3 * sizeof(float), (void *)0);
 }
+
+Mesh::Mesh(const std::vector<float> &vertices, const std::vector<unsigned int> &indices)
+    : m_VBO(const_cast<float *>(vertices.data()), vertices.size() * sizeof(float)),
+      m_IBO(const_cast<unsigned int *>(indices.data()), indices.size())
+{
+    m_VAO.Bind();
+    m_VBO.Bind();
+    m_IBO.Bind();
+
+    // Vertex layout: position (3) + normal (3) + texcoord (2) = 8 floats per vertex
+    const unsigned int stride = 8 * sizeof(float);
+
+    // Position attribute (location 0)
+    m_VAO.AddVertexAttribute(0, 3, GL_FLOAT, GL_FALSE, stride, (void *)0);
+
+    // Normal attribute (location 1)
+    m_VAO.AddVertexAttribute(1, 3, GL_FLOAT, GL_FALSE, stride, (void *)(3 * sizeof(float)));
+
+    // Texture coordinate attribute (location 2)
+    m_VAO.AddVertexAttribute(2, 2, GL_FLOAT, GL_FALSE, stride, (void *)(6 * sizeof(float)));
+}
+
 Mesh::~Mesh()
 {
     // VertexArray and VertexBuffer will be automatically cleaned up by their destructors

--- a/Engine/Graphics/Mesh.h
+++ b/Engine/Graphics/Mesh.h
@@ -3,24 +3,53 @@
 #include "VertexArray.h"
 #include "VertexBuffer.h"
 #include "IndexBuffer.h"
+#include <vector>
 
 /**
- * @class Mesh
- * @brief Represents a 3D mesh consisting of vertex and index data for rendering.
+ * @brief Represents a 3D mesh composed of vertices and indices.
  *
- * The Mesh class encapsulates the creation, management, and rendering of a mesh object.
- * It manages the underlying vertex array, vertex buffer, and index buffer objects.
+ * The Mesh class encapsulates the vertex data, index data, and the
+ * associated OpenGL objects (Vertex Array Object, Vertex Buffer Object,
+ * and Index Buffer Object) required to render a 3D model.
  */
 class Mesh
 {
 public:
+    /**
+     * @brief Constructs a Mesh object from raw C-style arrays.
+     * @param vertices Pointer to the array of vertex data (e.g., positions, normals, texture coordinates).
+     * @param vSize Total size of the vertex data array in bytes.
+     * @param indices Pointer to the array of indices that define the triangles.
+     * @param iCount Total number of indices.
+     */
     Mesh(float *vertices, unsigned int vSize, unsigned int *indices, unsigned int iCount);
+
+    /**
+     * @brief Constructs a Mesh object from C++ std::vector containers.
+     * @param vertices A constant reference to a vector of floats representing vertex data.
+     * @param indices A constant reference to a vector of unsigned integers representing index data.
+     */
+    Mesh(const std::vector<float> &vertices, const std::vector<unsigned int> &indices);
+
+    /**
+     * @brief Destroys the Mesh object.
+     *
+     * This destructor will handle the cleanup of OpenGL resources
+     * if the underlying VertexArray, VertexBuffer, and IndexBuffer
+     * classes manage their own resource deallocation.
+     */
     ~Mesh();
 
+    /**
+     * @brief Renders the mesh.
+     *
+     * This method binds the associated Vertex Array Object and issues a draw call
+     * using the Index Buffer Object.
+     */
     void Draw() const;
 
 private:
-    VertexArray m_VAO;
-    VertexBuffer m_VBO;
-    IndexBuffer m_IBO;
+    VertexArray m_VAO;  ///< Vertex Array Object managing the vertex attribute configurations.
+    VertexBuffer m_VBO; ///< Vertex Buffer Object storing the vertex data.
+    IndexBuffer m_IBO;  ///< Index Buffer Object storing the index data.
 };

--- a/Engine/Graphics/Renderer.cpp
+++ b/Engine/Graphics/Renderer.cpp
@@ -5,3 +5,10 @@ void Renderer::Draw(const Mesh &mesh, const Shader &shader) const
     shader.Bind();
     mesh.Draw();
 }
+
+void Renderer::Draw(const Mesh &mesh, const Shader &shader, const Mat4 &modelMatrix) const
+{
+    shader.Bind();
+    shader.SetUniformMat4("u_Model", modelMatrix.data);
+    mesh.Draw();
+}

--- a/Engine/Graphics/Renderer.h
+++ b/Engine/Graphics/Renderer.h
@@ -2,6 +2,7 @@
 
 #include "Shader.h"
 #include "Mesh.h"
+#include "Math/Mat4.h"
 
 /**
  * @class Renderer
@@ -18,4 +19,12 @@ class Renderer
 {
 public:
     void Draw(const Mesh &mesh, const Shader &shader) const;
+
+    /**
+     * @brief Draws a mesh with a specific model transformation matrix.
+     * @param mesh The mesh to draw.
+     * @param shader The shader to use for rendering.
+     * @param modelMatrix The model transformation matrix.
+     */
+    void Draw(const Mesh &mesh, const Shader &shader, const Mat4 &modelMatrix) const;
 };

--- a/Engine/Loader/AssimpLoader.cpp
+++ b/Engine/Loader/AssimpLoader.cpp
@@ -1,0 +1,214 @@
+#include "IFormatLoader.h"
+#include <iostream>
+#include <algorithm>
+
+// Include Assimp
+#include <assimp/Importer.hpp>
+#include <assimp/scene.h>
+#include <assimp/postprocess.h>
+
+using namespace Engine::Loader;
+
+// ===== AssimpLoader Implementation =====
+
+bool AssimpLoader::CanLoad(const std::string &extension) const
+{
+    std::string ext = extension;
+    std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
+
+    // Comprehensive list of formats supported by Assimp
+    static const std::vector<std::string> supportedFormats = {
+        // Common 3D formats
+        ".fbx",   // Autodesk FBX
+        ".dae",   // COLLADA
+        ".gltf",  // glTF 2.0
+        ".glb",   // Binary glTF
+        ".blend", // Blender
+
+        // Legacy formats
+        ".3ds",     // 3D Studio Max
+        ".max",     // 3D Studio Max
+        ".obj",     // Wavefront OBJ (backup if OBJLoader fails)
+        ".ply",     // Stanford PLY
+        ".stl",     // Stereolithography
+        ".x",       // DirectX X
+        ".ac",      // AC3D
+        ".ase",     // 3D Studio Max ASE
+        ".assbin",  // Assimp Binary
+        ".b3d",     // Blitz3D
+        ".bvh",     // Biovision Hierarchy
+        ".csm",     // CharacterStudio Motion
+        ".hmp",     // 3D GameStudio
+        ".ifc",     // Industry Foundation Classes
+        ".irrmesh", // Irrlicht Mesh
+        ".lwo",     // LightWave Object
+        ".lws",     // LightWave Scene
+        ".md2",     // Quake II
+        ".md3",     // Quake III
+        ".md5mesh", // Doom 3
+        ".mdc",     // Return to Castle Wolfenstein
+        ".mdl",     // Quake
+        ".nff",     // Neutral File Format
+        ".ndo",     // Nendo
+        ".off",     // Object File Format
+        ".ogex",    // Open Game Engine Exchange
+        ".raw",     // Raw Triangles
+        ".smd",     // Valve SMD
+        ".ter",     // Terragen Terrain
+        ".x3d",     // Extensible 3D
+        ".xgl",     // XGL
+        ".zgl",     // ZGL
+
+        // CAD formats
+        ".step", // STEP
+        ".stp",  // STEP
+        ".iges", // IGES
+        ".igs",  // IGES
+
+        // Game engine formats
+        ".ms3d",     // MilkShape 3D
+        ".cob",      // TrueSpace
+        ".scn",      // TrueSpace
+        ".mesh.xml", // Ogre3D
+        ".irr",      // Irrlicht Scene
+        ".pmx",      // MikuMikuDance
+        ".q3o",      // Quick3D Object
+        ".q3s"       // Quick3D Scene
+    };
+
+    return std::find(supportedFormats.begin(), supportedFormats.end(), ext) != supportedFormats.end();
+}
+
+std::vector<MeshData> AssimpLoader::LoadMeshData(const std::string &filepath)
+{
+    std::vector<MeshData> result;
+
+    Assimp::Importer importer;
+
+    // Configure import settings for optimal processing
+    unsigned int flags =
+        aiProcess_Triangulate |              // Convert all faces to triangles
+        aiProcess_FlipUVs |                  // Flip UV coordinates (OpenGL convention)
+        aiProcess_GenSmoothNormals |         // Generate smooth normals if missing
+        aiProcess_CalcTangentSpace |         // Calculate tangent space for normal mapping
+        aiProcess_JoinIdenticalVertices |    // Remove duplicate vertices
+        aiProcess_SortByPType |              // Sort primitives by type
+        aiProcess_OptimizeMeshes |           // Optimize mesh structure
+        aiProcess_OptimizeGraph |            // Optimize scene graph
+        aiProcess_ValidateDataStructure |    // Validate data structure
+        aiProcess_ImproveCacheLocality |     // Improve cache locality
+        aiProcess_RemoveRedundantMaterials | // Remove redundant materials
+        aiProcess_FixInfacingNormals |       // Fix inward-facing normals
+        aiProcess_FindDegenerates |          // Find degenerate triangles
+        aiProcess_FindInvalidData |          // Find invalid data
+        aiProcess_GenBoundingBoxes;          // Generate bounding boxes
+
+    const aiScene *scene = importer.ReadFile(filepath, flags);
+
+    if (!scene || scene->mFlags & AI_SCENE_FLAGS_INCOMPLETE || !scene->mRootNode)
+    {
+        throw std::runtime_error("Assimp error loading " + filepath + ": " + std::string(importer.GetErrorString()));
+    }
+
+    std::cout << "Loading with Assimp: " << filepath << std::endl;
+    std::cout << "Scene contains " << scene->mNumMeshes << " meshes" << std::endl;
+
+    // Process all meshes in the scene
+    for (unsigned int i = 0; i < scene->mNumMeshes; i++)
+    {
+        aiMesh *mesh = scene->mMeshes[i];
+        MeshData data = ProcessMesh(mesh, const_cast<aiScene *>(scene));
+
+        if (!data.vertices.empty())
+        {
+            // Set mesh name
+            data.name = mesh->mName.C_Str();
+            if (data.name.empty())
+            {
+                data.name = "Mesh_" + std::to_string(i);
+            }
+
+            result.push_back(std::move(data));
+        }
+    }
+
+    if (!result.empty())
+    {
+        std::cout << "Successfully loaded " << result.size() << " meshes from: " << filepath << std::endl;
+        size_t totalVertices = 0, totalFaces = 0;
+        for (const auto &mesh : result)
+        {
+            totalVertices += mesh.vertices.size() / 8;
+            totalFaces += mesh.indices.size() / 3;
+        }
+        std::cout << "Total vertices: " << totalVertices << ", Total faces: " << totalFaces << std::endl;
+    }
+
+    return result;
+}
+
+MeshData AssimpLoader::ProcessMesh(void *meshPtr, void *scenePtr)
+{
+    aiMesh *mesh = static_cast<aiMesh *>(meshPtr);
+    const aiScene *scene = static_cast<const aiScene *>(scenePtr);
+
+    MeshData data;
+
+    // Process vertices
+    for (unsigned int i = 0; i < mesh->mNumVertices; i++)
+    {
+        // Position (required)
+        data.vertices.push_back(mesh->mVertices[i].x);
+        data.vertices.push_back(mesh->mVertices[i].y);
+        data.vertices.push_back(mesh->mVertices[i].z);
+
+        // Normal (default to up if not present)
+        if (mesh->HasNormals())
+        {
+            data.vertices.push_back(mesh->mNormals[i].x);
+            data.vertices.push_back(mesh->mNormals[i].y);
+            data.vertices.push_back(mesh->mNormals[i].z);
+        }
+        else
+        {
+            data.vertices.push_back(0.0f);
+            data.vertices.push_back(1.0f);
+            data.vertices.push_back(0.0f);
+        }
+
+        // Texture coordinates (use first UV channel, default to 0,0 if not present)
+        if (mesh->mTextureCoords[0])
+        {
+            data.vertices.push_back(mesh->mTextureCoords[0][i].x);
+            data.vertices.push_back(mesh->mTextureCoords[0][i].y);
+        }
+        else
+        {
+            data.vertices.push_back(0.0f);
+            data.vertices.push_back(0.0f);
+        }
+    }
+
+    // Process indices
+    for (unsigned int i = 0; i < mesh->mNumFaces; i++)
+    {
+        aiFace face = mesh->mFaces[i];
+        for (unsigned int j = 0; j < face.mNumIndices; j++)
+        {
+            data.indices.push_back(face.mIndices[j]);
+        }
+    }
+
+    // Store material information if available
+    if (mesh->mMaterialIndex >= 0 && scene->mMaterials)
+    {
+        aiMaterial *material = scene->mMaterials[mesh->mMaterialIndex];
+        aiString materialName;
+        if (material->Get(AI_MATKEY_NAME, materialName) == AI_SUCCESS)
+        {
+            data.materialName = materialName.C_Str();
+        }
+    }
+
+    return data;
+}

--- a/Engine/Loader/IFormatLoader.h
+++ b/Engine/Loader/IFormatLoader.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include <memory>
+#include "../Graphics/Mesh.h"
+
+namespace Engine::Loader
+{
+    /**
+     * @struct MeshData
+     * @brief Raw mesh data loaded from files
+     */
+    struct MeshData
+    {
+        std::vector<float> vertices; // Position(3) + Normal(3) + TexCoord(2) per vertex
+        std::vector<unsigned int> indices;
+        std::string name;
+        std::string materialName; // Optional material reference
+    };
+
+    /**
+     * @class IFormatLoader
+     * @brief Abstract base class for different mesh format loaders
+     */
+    class IFormatLoader
+    {
+    public:
+        virtual ~IFormatLoader() = default;
+
+        /**
+         * @brief Check if this loader can handle the given file extension
+         * @param extension File extension (e.g., ".obj", ".fbx")
+         * @return True if format is supported
+         */
+        virtual bool CanLoad(const std::string &extension) const = 0;
+
+        /**
+         * @brief Load mesh data from file
+         * @param filepath Path to the mesh file
+         * @return Vector of MeshData structures
+         */
+        virtual std::vector<MeshData> LoadMeshData(const std::string &filepath) = 0;
+
+        /**
+         * @brief Get the name of this loader
+         * @return Loader name for debugging
+         */
+        virtual std::string GetLoaderName() const = 0;
+    };
+
+    /**
+     * @class OBJLoader
+     * @brief Loader for Wavefront OBJ files
+     */
+    class OBJLoader : public IFormatLoader
+    {
+    public:
+        bool CanLoad(const std::string &extension) const override;
+        std::vector<MeshData> LoadMeshData(const std::string &filepath) override;
+        std::string GetLoaderName() const override { return "OBJ Loader"; }
+    };
+
+    /**
+     * @class AssimpLoader
+     * @brief Loader using Assimp library for multiple formats
+     * Supports: FBX, GLTF, GLB, 3DS, DAE, PLY, STL, X3D, and many more
+     */
+    class AssimpLoader : public IFormatLoader
+    {
+    public:
+        bool CanLoad(const std::string &extension) const override;
+        std::vector<MeshData> LoadMeshData(const std::string &filepath) override;
+        std::string GetLoaderName() const override { return "Assimp Loader"; }
+
+    private:
+        /**
+         * @brief Process an Assimp mesh node
+         * @param mesh Assimp mesh pointer
+         * @param scene Assimp scene pointer
+         * @return Converted MeshData
+         */
+        MeshData ProcessMesh(void *mesh, void *scene);
+    };
+}

--- a/Engine/Loader/MeshLoader.cpp
+++ b/Engine/Loader/MeshLoader.cpp
@@ -1,0 +1,185 @@
+#include "MeshLoader.h"
+#include "IFormatLoader.h"
+#include <iostream>
+#include <filesystem>
+#include <algorithm>
+
+using namespace Engine::Loader;
+
+std::shared_ptr<Mesh> MeshLoader::LoadMesh(const std::string &filepath)
+{
+    auto meshes = LoadMeshes(filepath);
+    if (meshes.empty())
+    {
+        std::cerr << "Failed to load any mesh from: " << filepath << std::endl;
+        return nullptr;
+    }
+
+    return meshes[0]; // Return first mesh
+}
+
+std::vector<std::shared_ptr<Mesh>> MeshLoader::LoadMeshes(const std::string &filepath)
+{
+    std::vector<std::shared_ptr<Mesh>> meshes;
+
+    if (!std::filesystem::exists(filepath))
+    {
+        std::cerr << "File does not exist: " << filepath << std::endl;
+        return meshes;
+    }
+
+    if (!IsFormatSupported(filepath))
+    {
+        std::cerr << "Unsupported file format: " << filepath << std::endl;
+        return meshes;
+    }
+
+    auto meshData = LoadMeshData(filepath);
+
+    for (const auto &data : meshData)
+    {
+        if (!data.vertices.empty() && !data.indices.empty())
+        {
+            auto mesh = std::make_shared<Mesh>(data.vertices, data.indices);
+            meshes.push_back(mesh);
+        }
+    }
+
+    return meshes;
+}
+
+std::vector<MeshData> MeshLoader::LoadMeshData(const std::string &filepath)
+{
+    try
+    {
+        std::string extension = GetFileExtension(filepath);
+        auto loader = GetLoaderForExtension(extension);
+
+        if (!loader)
+        {
+            std::cerr << "No loader available for extension: " << extension << std::endl;
+            return {};
+        }
+
+        std::cout << "Using " << loader->GetLoaderName() << " for file: " << filepath << std::endl;
+        return loader->LoadMeshData(filepath);
+    }
+    catch (const std::exception &e)
+    {
+        std::cerr << "Error loading mesh: " << e.what() << std::endl;
+        return {};
+    }
+}
+
+bool MeshLoader::IsFormatSupported(const std::string &filepath)
+{
+    std::string extension = GetFileExtension(filepath);
+    return GetLoaderForExtension(extension) != nullptr;
+}
+
+std::vector<std::string> MeshLoader::GetSupportedFormats()
+{
+    std::vector<std::string> allFormats;
+    auto loaders = GetAllLoaders();
+
+    for (auto &loader : loaders)
+    {
+        // Test common extensions to see what each loader supports
+        std::vector<std::string> testExtensions = {
+            ".obj", ".fbx", ".dae", ".gltf", ".glb", ".3ds", ".ply", ".stl",
+            ".blend", ".x", ".ac", ".ase", ".b3d", ".bvh", ".csm", ".hmp",
+            ".ifc", ".irrmesh", ".lwo", ".lws", ".md2", ".md3", ".md5mesh",
+            ".mdc", ".mdl", ".nff", ".ndo", ".off", ".ogex", ".raw", ".smd",
+            ".ter", ".x3d", ".xgl", ".zgl", ".step", ".stp", ".iges", ".igs",
+            ".ms3d", ".cob", ".scn", ".mesh.xml", ".irr", ".pmx", ".q3o", ".q3s"};
+
+        for (const auto &ext : testExtensions)
+        {
+            if (loader->CanLoad(ext))
+            {
+                if (std::find(allFormats.begin(), allFormats.end(), ext) == allFormats.end())
+                {
+                    allFormats.push_back(ext);
+                }
+            }
+        }
+    }
+
+    std::sort(allFormats.begin(), allFormats.end());
+    return allFormats;
+}
+
+std::vector<std::pair<std::string, std::vector<std::string>>> MeshLoader::GetLoaderInfo()
+{
+    std::vector<std::pair<std::string, std::vector<std::string>>> info;
+    auto loaders = GetAllLoaders();
+
+    for (auto &loader : loaders)
+    {
+        std::vector<std::string> supportedFormats;
+
+        // Test extensions for this specific loader
+        std::vector<std::string> testExtensions = {
+            ".obj", ".fbx", ".dae", ".gltf", ".glb", ".3ds", ".ply", ".stl",
+            ".blend", ".x", ".ac", ".ase", ".b3d", ".bvh", ".csm", ".hmp",
+            ".ifc", ".irrmesh", ".lwo", ".lws", ".md2", ".md3", ".md5mesh",
+            ".mdc", ".mdl", ".nff", ".ndo", ".off", ".ogex", ".raw", ".smd",
+            ".ter", ".x3d", ".xgl", ".zgl", ".step", ".stp", ".iges", ".igs",
+            ".ms3d", ".cob", ".scn", ".mesh.xml", ".irr", ".pmx", ".q3o", ".q3s"};
+
+        for (const auto &ext : testExtensions)
+        {
+            if (loader->CanLoad(ext))
+            {
+                supportedFormats.push_back(ext);
+            }
+        }
+
+        info.emplace_back(loader->GetLoaderName(), std::move(supportedFormats));
+    }
+
+    return info;
+}
+
+std::shared_ptr<IFormatLoader> MeshLoader::GetLoaderForExtension(const std::string &extension)
+{
+    auto loaders = GetAllLoaders();
+
+    for (auto &loader : loaders)
+    {
+        if (loader->CanLoad(extension))
+        {
+            return loader;
+        }
+    }
+
+    return nullptr;
+}
+
+std::string MeshLoader::GetFileExtension(const std::string &filepath)
+{
+    size_t lastDot = filepath.find_last_of('.');
+    if (lastDot == std::string::npos)
+        return "";
+
+    std::string extension = filepath.substr(lastDot);
+    std::transform(extension.begin(), extension.end(), extension.begin(), ::tolower);
+    return extension;
+}
+
+std::vector<std::shared_ptr<IFormatLoader>> MeshLoader::GetAllLoaders()
+{
+    static std::vector<std::shared_ptr<IFormatLoader>> loaders;
+
+    // Initialize loaders only once
+    if (loaders.empty())
+    {
+        // Add OBJ loader (lightweight, specific implementation)
+        loaders.push_back(std::make_shared<OBJLoader>());
+
+        // Add Assimp loader (comprehensive, handles most formats)
+        loaders.push_back(std::make_shared<AssimpLoader>());
+    }
+
+    return loaders;
+}

--- a/Engine/Loader/MeshLoader.h
+++ b/Engine/Loader/MeshLoader.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include <memory>
+#include "../Graphics/Mesh.h"
+#include "IFormatLoader.h"
+
+namespace Engine::Loader
+{
+    /**
+     * @class MeshLoader
+     * @brief Main mesh loading facade that manages multiple format loaders
+     *
+     * This class provides a clean interface for loading 3D models from external files.
+     * It automatically selects the appropriate loader based on file extension and
+     * supports a wide range of formats through different loader implementations.
+     */
+    class MeshLoader
+    {
+    public:
+        /**
+         * @brief Load a single mesh from file (first mesh if file contains multiple)
+         * @param filepath Path to the mesh file
+         * @return Shared pointer to loaded mesh, or nullptr if failed
+         */
+        static std::shared_ptr<Mesh> LoadMesh(const std::string &filepath);
+
+        /**
+         * @brief Load all meshes from file
+         * @param filepath Path to the mesh file
+         * @return Vector of shared pointers to all loaded meshes
+         */
+        static std::vector<std::shared_ptr<Mesh>> LoadMeshes(const std::string &filepath);
+
+        /**
+         * @brief Load raw mesh data for custom processing
+         * @param filepath Path to the mesh file
+         * @return Vector of MeshData structures
+         */
+        static std::vector<MeshData> LoadMeshData(const std::string &filepath);
+
+        /**
+         * @brief Check if file format is supported
+         * @param filepath Path to check
+         * @return True if format is supported
+         */
+        static bool IsFormatSupported(const std::string &filepath);
+
+        /**
+         * @brief Get list of all supported file extensions
+         * @return Vector of supported extensions (e.g., ".obj", ".fbx")
+         */
+        static std::vector<std::string> GetSupportedFormats();
+
+        /**
+         * @brief Get information about available loaders
+         * @return Vector of loader names and their supported formats
+         */
+        static std::vector<std::pair<std::string, std::vector<std::string>>> GetLoaderInfo();
+
+    private:
+        /**
+         * @brief Get the appropriate loader for a file extension
+         * @param extension File extension
+         * @return Pointer to loader, or nullptr if not supported
+         */
+        static std::shared_ptr<IFormatLoader> GetLoaderForExtension(const std::string &extension);
+
+        /**
+         * @brief Get file extension from filepath
+         * @param filepath File path
+         * @return Extension string (including dot)
+         */
+        static std::string GetFileExtension(const std::string &filepath);
+
+        /**
+         * @brief Initialize all available loaders
+         * @return Vector of all available loaders
+         */
+        static std::vector<std::shared_ptr<IFormatLoader>> GetAllLoaders();
+    };
+};

--- a/Engine/Loader/OBJLoader.cpp
+++ b/Engine/Loader/OBJLoader.cpp
@@ -1,0 +1,141 @@
+#include "IFormatLoader.h"
+#include <iostream>
+#include <fstream>
+#include <sstream>
+#include <filesystem>
+#include <algorithm>
+#include "../Math/Vec3.h"
+#include "../Math/Vec2.h"
+
+using namespace Engine::Loader;
+
+// ===== OBJLoader Implementation =====
+
+bool OBJLoader::CanLoad(const std::string &extension) const
+{
+    std::string ext = extension;
+    std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
+    return ext == ".obj";
+}
+
+std::vector<MeshData> OBJLoader::LoadMeshData(const std::string &filepath)
+{
+    std::vector<MeshData> result;
+    MeshData meshData;
+    meshData.name = std::filesystem::path(filepath).stem().string();
+
+    std::vector<Vec3> positions;
+    std::vector<Vec3> normals;
+    std::vector<Vec2> texCoords;
+
+    std::ifstream file(filepath);
+    if (!file.is_open())
+    {
+        throw std::runtime_error("Cannot open OBJ file: " + filepath);
+    }
+
+    std::string line;
+    while (std::getline(file, line))
+    {
+        std::istringstream iss(line);
+        std::string type;
+        iss >> type;
+
+        if (type == "v") // Vertex position
+        {
+            Vec3 pos;
+            iss >> pos.x >> pos.y >> pos.z;
+            positions.push_back(pos);
+        }
+        else if (type == "vn") // Vertex normal
+        {
+            Vec3 normal;
+            iss >> normal.x >> normal.y >> normal.z;
+            normals.push_back(normal);
+        }
+        else if (type == "vt") // Texture coordinate
+        {
+            Vec2 texCoord;
+            iss >> texCoord.x >> texCoord.y;
+            texCoords.push_back(texCoord);
+        }
+        else if (type == "f") // Face
+        {
+            std::string vertex1, vertex2, vertex3;
+            iss >> vertex1 >> vertex2 >> vertex3;
+
+            // Parse face indices (format: v/vt/vn or v//vn or v/vt or v)
+            auto parseVertex = [&](const std::string &vertexStr) -> unsigned int
+            {
+                std::istringstream viss(vertexStr);
+                std::string posIdx, texIdx, normalIdx;
+
+                std::getline(viss, posIdx, '/');
+                std::getline(viss, texIdx, '/');
+                std::getline(viss, normalIdx, '/');
+
+                int pIdx = std::stoi(posIdx) - 1; // OBJ indices are 1-based
+                int tIdx = texIdx.empty() ? -1 : std::stoi(texIdx) - 1;
+                int nIdx = normalIdx.empty() ? -1 : std::stoi(normalIdx) - 1;
+
+                // Add vertex data: position(3) + normal(3) + texcoord(2)
+                if (pIdx >= 0 && pIdx < positions.size())
+                {
+                    Vec3 pos = positions[pIdx];
+                    meshData.vertices.push_back(pos.x);
+                    meshData.vertices.push_back(pos.y);
+                    meshData.vertices.push_back(pos.z);
+                }
+
+                // Normal (default to up if not available)
+                if (nIdx >= 0 && nIdx < normals.size())
+                {
+                    Vec3 normal = normals[nIdx];
+                    meshData.vertices.push_back(normal.x);
+                    meshData.vertices.push_back(normal.y);
+                    meshData.vertices.push_back(normal.z);
+                }
+                else
+                {
+                    meshData.vertices.push_back(0.0f);
+                    meshData.vertices.push_back(1.0f);
+                    meshData.vertices.push_back(0.0f);
+                }
+
+                // Texture coordinate (default to 0,0 if not available)
+                if (tIdx >= 0 && tIdx < texCoords.size())
+                {
+                    Vec2 texCoord = texCoords[tIdx];
+                    meshData.vertices.push_back(texCoord.x);
+                    meshData.vertices.push_back(texCoord.y);
+                }
+                else
+                {
+                    meshData.vertices.push_back(0.0f);
+                    meshData.vertices.push_back(0.0f);
+                }
+
+                return static_cast<unsigned int>((meshData.vertices.size() / 8) - 1); // 8 floats per vertex
+            };
+
+            unsigned int idx1 = parseVertex(vertex1);
+            unsigned int idx2 = parseVertex(vertex2);
+            unsigned int idx3 = parseVertex(vertex3);
+
+            meshData.indices.push_back(idx1);
+            meshData.indices.push_back(idx2);
+            meshData.indices.push_back(idx3);
+        }
+    }
+
+    file.close();
+
+    if (!meshData.vertices.empty())
+    {
+        result.push_back(std::move(meshData));
+        std::cout << "Successfully loaded OBJ file: " << filepath << std::endl;
+        std::cout << "Vertices: " << meshData.vertices.size() / 8 << ", Faces: " << meshData.indices.size() / 3 << std::endl;
+    }
+
+    return result;
+}

--- a/Engine/Math/Transform.cpp
+++ b/Engine/Math/Transform.cpp
@@ -1,0 +1,110 @@
+#include "Transform.h"
+#include "MathUtil.h"
+#include <cmath>
+
+#define DEG2RAD 0.01745329251994329576923690768489f // pi / 180.0f
+
+Transform::Transform()
+    : m_Position(0.0f, 0.0f, 0.0f), m_Rotation(0.0f, 0.0f, 0.0f), m_Scale(1.0f, 1.0f, 1.0f)
+{
+}
+
+Transform::Transform(const Vec3 &position)
+    : m_Position(position), m_Rotation(0.0f, 0.0f, 0.0f), m_Scale(1.0f, 1.0f, 1.0f)
+{
+}
+
+Transform::Transform(const Vec3 &position, const Vec3 &rotation, const Vec3 &scale)
+    : m_Position(position), m_Rotation(rotation), m_Scale(scale)
+{
+}
+
+void Transform::SetPosition(const Vec3 &position)
+{
+    m_Position = position;
+    InvalidateMatrix();
+}
+
+void Transform::SetRotation(const Vec3 &rotation)
+{
+    m_Rotation = rotation;
+    InvalidateMatrix();
+}
+
+void Transform::SetScale(const Vec3 &scale)
+{
+    m_Scale = scale;
+    InvalidateMatrix();
+}
+
+void Transform::SetScale(float uniformScale)
+{
+    m_Scale = Vec3(uniformScale, uniformScale, uniformScale);
+    InvalidateMatrix();
+}
+
+void Transform::Translate(const Vec3 &translation)
+{
+    m_Position = m_Position + translation;
+    InvalidateMatrix();
+}
+
+void Transform::Rotate(const Vec3 &rotation)
+{
+    m_Rotation = m_Rotation + rotation;
+    InvalidateMatrix();
+}
+
+void Transform::Scale(const Vec3 &scale)
+{
+    m_Scale.x *= scale.x;
+    m_Scale.y *= scale.y;
+    m_Scale.z *= scale.z;
+    InvalidateMatrix();
+}
+
+void Transform::Scale(float uniformScale)
+{
+    m_Scale.x *= uniformScale;
+    m_Scale.y *= uniformScale;
+    m_Scale.z *= uniformScale;
+    InvalidateMatrix();
+}
+
+Mat4 Transform::GetMatrix() const
+{
+    if (m_MatrixDirty)
+    {
+        UpdateMatrix();
+        m_MatrixDirty = false;
+    }
+    return m_CachedMatrix;
+}
+
+Mat4 Transform::GetInverseMatrix() const
+{
+    // For a TRS matrix, the inverse is: S^-1 * R^-1 * T^-1
+    Mat4 invScale = Mat4::Scale(Vec3(1.0f / m_Scale.x, 1.0f / m_Scale.y, 1.0f / m_Scale.z));
+    Mat4 invRotation = Mat4::RotateZ(-m_Rotation.z * DEG2RAD); // Simple Z rotation for now
+    Mat4 invTranslation = Mat4::Translate(Vec3(-m_Position.x, -m_Position.y, -m_Position.z));
+
+    return invScale * invRotation * invTranslation;
+}
+
+void Transform::Reset()
+{
+    m_Position = Vec3(0.0f, 0.0f, 0.0f);
+    m_Rotation = Vec3(0.0f, 0.0f, 0.0f);
+    m_Scale = Vec3(1.0f, 1.0f, 1.0f);
+    InvalidateMatrix();
+}
+
+void Transform::UpdateMatrix() const
+{
+    // Create TRS matrix: Translation * Rotation * Scale
+    Mat4 translation = Mat4::Translate(m_Position);
+    Mat4 rotation = Mat4::RotateZ(m_Rotation.z * DEG2RAD); // For now, just Z rotation
+    Mat4 scale = Mat4::Scale(m_Scale);
+
+    m_CachedMatrix = translation * rotation * scale;
+}

--- a/Engine/Math/Transform.h
+++ b/Engine/Math/Transform.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include "Vec3.h"
+#include "Mat4.h"
+
+/**
+ * @class Transform
+ * @brief Represents a 3D transformation with position, rotation, and scale.
+ *
+ * The Transform class encapsulates 3D transformations including translation,
+ * rotation (using Euler angles), and uniform/non-uniform scaling. It provides
+ * methods to compute transformation matrices and manipulate the transform.
+ */
+class Transform
+{
+public:
+    /**
+     * @brief Default constructor - creates identity transform.
+     */
+    Transform();
+
+    /**
+     * @brief Constructor with position.
+     * @param position Initial position.
+     */
+    Transform(const Vec3 &position);
+
+    /**
+     * @brief Constructor with position, rotation, and scale.
+     * @param position Initial position.
+     * @param rotation Initial rotation in degrees (Euler angles).
+     * @param scale Initial scale.
+     */
+    Transform(const Vec3 &position, const Vec3 &rotation, const Vec3 &scale);
+
+    // Getters
+    const Vec3 &GetPosition() const { return m_Position; }
+    const Vec3 &GetRotation() const { return m_Rotation; }
+    const Vec3 &GetScale() const { return m_Scale; }
+
+    // Setters
+    void SetPosition(const Vec3 &position);
+    void SetRotation(const Vec3 &rotation);
+    void SetScale(const Vec3 &scale);
+    void SetScale(float uniformScale);
+
+    // Transformation operations
+    void Translate(const Vec3 &translation);
+    void Rotate(const Vec3 &rotation);
+    void Scale(const Vec3 &scale);
+    void Scale(float uniformScale);
+
+    /**
+     * @brief Gets the transformation matrix.
+     * @return The 4x4 transformation matrix (Translation * Rotation * Scale).
+     */
+    Mat4 GetMatrix() const;
+
+    /**
+     * @brief Gets the inverse transformation matrix.
+     * @return The inverse transformation matrix.
+     */
+    Mat4 GetInverseMatrix() const;
+
+    /**
+     * @brief Resets transform to identity.
+     */
+    void Reset();
+
+private:
+    Vec3 m_Position{0.0f, 0.0f, 0.0f};
+    Vec3 m_Rotation{0.0f, 0.0f, 0.0f}; // Euler angles in degrees
+    Vec3 m_Scale{1.0f, 1.0f, 1.0f};
+
+    mutable Mat4 m_CachedMatrix;
+    mutable bool m_MatrixDirty = true;
+
+    void InvalidateMatrix() const { m_MatrixDirty = true; }
+    void UpdateMatrix() const;
+};

--- a/Engine/Math/Vec2.h
+++ b/Engine/Math/Vec2.h
@@ -1,0 +1,42 @@
+#pragma once
+
+/**
+ * @struct Vec2
+ * @brief Represents a 2-dimensional vector with float components
+ */
+struct Vec2
+{
+    float x, y; ///< The x and y components of the vector.
+
+    /// Default constructor. Initializes all components to zero.
+    Vec2() : x(0.0f), y(0.0f) {}
+
+    /// Constructs a vector with the given x and y components.
+    /// @param x The x component.
+    /// @param y The y component.
+    Vec2(float x, float y) : x(x), y(y) {}
+
+    /// Adds this vector to another vector.
+    /// @param other The vector to add.
+    /// @return The result of vector addition.
+    Vec2 operator+(const Vec2 &other) const
+    {
+        return Vec2(x + other.x, y + other.y);
+    }
+
+    /// Subtracts another vector from this vector.
+    /// @param other The vector to subtract.
+    /// @return The result of vector subtraction.
+    Vec2 operator-(const Vec2 &other) const
+    {
+        return Vec2(x - other.x, y - other.y);
+    }
+
+    /// Multiplies this vector by a scalar.
+    /// @param scalar The scalar value.
+    /// @return The result of scalar multiplication.
+    Vec2 operator*(float scalar) const
+    {
+        return Vec2(x * scalar, y * scalar);
+    }
+};

--- a/Engine/Scene/PrimitiveGenerator.cpp
+++ b/Engine/Scene/PrimitiveGenerator.cpp
@@ -1,0 +1,249 @@
+#include "PrimitiveGenerator.h"
+#include <cmath>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+std::shared_ptr<Mesh> PrimitiveGenerator::CreateCube(float size)
+{
+    float halfSize = size * 0.5f;
+
+    // Cube vertices: position (3) + normal (3) + texcoord (2) = 8 floats per vertex
+    std::vector<float> vertices = {
+        // Front face
+        -halfSize, -halfSize, halfSize, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f,
+        halfSize, -halfSize, halfSize, 0.0f, 0.0f, 1.0f, 1.0f, 0.0f,
+        halfSize, halfSize, halfSize, 0.0f, 0.0f, 1.0f, 1.0f, 1.0f,
+        -halfSize, halfSize, halfSize, 0.0f, 0.0f, 1.0f, 0.0f, 1.0f,
+
+        // Back face
+        -halfSize, -halfSize, -halfSize, 0.0f, 0.0f, -1.0f, 1.0f, 0.0f,
+        -halfSize, halfSize, -halfSize, 0.0f, 0.0f, -1.0f, 1.0f, 1.0f,
+        halfSize, halfSize, -halfSize, 0.0f, 0.0f, -1.0f, 0.0f, 1.0f,
+        halfSize, -halfSize, -halfSize, 0.0f, 0.0f, -1.0f, 0.0f, 0.0f,
+
+        // Left face
+        -halfSize, -halfSize, -halfSize, -1.0f, 0.0f, 0.0f, 0.0f, 0.0f,
+        -halfSize, -halfSize, halfSize, -1.0f, 0.0f, 0.0f, 1.0f, 0.0f,
+        -halfSize, halfSize, halfSize, -1.0f, 0.0f, 0.0f, 1.0f, 1.0f,
+        -halfSize, halfSize, -halfSize, -1.0f, 0.0f, 0.0f, 0.0f, 1.0f,
+
+        // Right face
+        halfSize, -halfSize, -halfSize, 1.0f, 0.0f, 0.0f, 1.0f, 0.0f,
+        halfSize, halfSize, -halfSize, 1.0f, 0.0f, 0.0f, 1.0f, 1.0f,
+        halfSize, halfSize, halfSize, 1.0f, 0.0f, 0.0f, 0.0f, 1.0f,
+        halfSize, -halfSize, halfSize, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f,
+
+        // Top face
+        -halfSize, halfSize, -halfSize, 0.0f, 1.0f, 0.0f, 0.0f, 1.0f,
+        -halfSize, halfSize, halfSize, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f,
+        halfSize, halfSize, halfSize, 0.0f, 1.0f, 0.0f, 1.0f, 0.0f,
+        halfSize, halfSize, -halfSize, 0.0f, 1.0f, 0.0f, 1.0f, 1.0f,
+
+        // Bottom face
+        -halfSize, -halfSize, -halfSize, 0.0f, -1.0f, 0.0f, 1.0f, 1.0f,
+        halfSize, -halfSize, -halfSize, 0.0f, -1.0f, 0.0f, 0.0f, 1.0f,
+        halfSize, -halfSize, halfSize, 0.0f, -1.0f, 0.0f, 0.0f, 0.0f,
+        -halfSize, -halfSize, halfSize, 0.0f, -1.0f, 0.0f, 1.0f, 0.0f};
+
+    std::vector<unsigned int> indices = {
+        // Front face
+        0, 1, 2, 2, 3, 0,
+        // Back face
+        4, 5, 6, 6, 7, 4,
+        // Left face
+        8, 9, 10, 10, 11, 8,
+        // Right face
+        12, 13, 14, 14, 15, 12,
+        // Top face
+        16, 17, 18, 18, 19, 16,
+        // Bottom face
+        20, 21, 22, 22, 23, 20};
+
+    return std::make_shared<Mesh>(vertices, indices);
+}
+
+std::shared_ptr<Mesh> PrimitiveGenerator::CreatePlane(float width, float height, int widthSegments, int heightSegments)
+{
+    std::vector<float> vertices;
+    std::vector<unsigned int> indices;
+
+    float halfWidth = width * 0.5f;
+    float halfHeight = height * 0.5f;
+
+    // Generate vertices
+    for (int y = 0; y <= heightSegments; y++)
+    {
+        for (int x = 0; x <= widthSegments; x++)
+        {
+            float u = (float)x / widthSegments;
+            float v = (float)y / heightSegments;
+
+            float posX = (u - 0.5f) * width;
+            float posZ = (v - 0.5f) * height;
+
+            AddVertex(vertices, posX, 0.0f, posZ, 0.0f, 1.0f, 0.0f, u, v);
+        }
+    }
+
+    // Generate indices
+    for (int y = 0; y < heightSegments; y++)
+    {
+        for (int x = 0; x < widthSegments; x++)
+        {
+            int a = y * (widthSegments + 1) + x;
+            int b = a + 1;
+            int c = (y + 1) * (widthSegments + 1) + x;
+            int d = c + 1;
+
+            AddTriangle(indices, a, b, c);
+            AddTriangle(indices, b, d, c);
+        }
+    }
+
+    return std::make_shared<Mesh>(vertices, indices);
+}
+
+std::shared_ptr<Mesh> PrimitiveGenerator::CreateSphere(float radius, int widthSegments, int heightSegments)
+{
+    std::vector<float> vertices;
+    std::vector<unsigned int> indices;
+
+    // Generate vertices
+    for (int y = 0; y <= heightSegments; y++)
+    {
+        float phi = M_PI * (float)y / heightSegments;
+
+        for (int x = 0; x <= widthSegments; x++)
+        {
+            float theta = 2.0f * M_PI * (float)x / widthSegments;
+
+            float cosTheta = cosf(theta);
+            float sinTheta = sinf(theta);
+            float cosPhi = cosf(phi);
+            float sinPhi = sinf(phi);
+
+            float posX = radius * sinPhi * cosTheta;
+            float posY = radius * cosPhi;
+            float posZ = radius * sinPhi * sinTheta;
+
+            // Normal is the same as position for a unit sphere
+            float nx = sinPhi * cosTheta;
+            float ny = cosPhi;
+            float nz = sinPhi * sinTheta;
+
+            float u = (float)x / widthSegments;
+            float v = (float)y / heightSegments;
+
+            AddVertex(vertices, posX, posY, posZ, nx, ny, nz, u, v);
+        }
+    }
+
+    // Generate indices
+    for (int y = 0; y < heightSegments; y++)
+    {
+        for (int x = 0; x < widthSegments; x++)
+        {
+            int a = y * (widthSegments + 1) + x;
+            int b = a + 1;
+            int c = (y + 1) * (widthSegments + 1) + x;
+            int d = c + 1;
+
+            if (y != 0) // Skip top cap
+                AddTriangle(indices, a, b, c);
+            if (y != heightSegments - 1) // Skip bottom cap
+                AddTriangle(indices, b, d, c);
+        }
+    }
+
+    return std::make_shared<Mesh>(vertices, indices);
+}
+
+std::shared_ptr<Mesh> PrimitiveGenerator::CreateCylinder(float radiusTop, float radiusBottom,
+                                                         float height, int radialSegments, int heightSegments)
+{
+    std::vector<float> vertices;
+    std::vector<unsigned int> indices;
+
+    float halfHeight = height * 0.5f;
+
+    // Generate side vertices
+    for (int y = 0; y <= heightSegments; y++)
+    {
+        float v = (float)y / heightSegments;
+        float posY = -halfHeight + v * height;
+        float radius = radiusBottom + v * (radiusTop - radiusBottom);
+
+        for (int x = 0; x <= radialSegments; x++)
+        {
+            float u = (float)x / radialSegments;
+            float theta = 2.0f * M_PI * u;
+
+            float cosTheta = cosf(theta);
+            float sinTheta = sinf(theta);
+
+            float posX = radius * cosTheta;
+            float posZ = radius * sinTheta;
+
+            // Normal calculation for cylinder
+            float nx = cosTheta;
+            float ny = 0.0f;
+            float nz = sinTheta;
+
+            AddVertex(vertices, posX, posY, posZ, nx, ny, nz, u, v);
+        }
+    }
+
+    // Generate side indices
+    for (int y = 0; y < heightSegments; y++)
+    {
+        for (int x = 0; x < radialSegments; x++)
+        {
+            int a = y * (radialSegments + 1) + x;
+            int b = a + 1;
+            int c = (y + 1) * (radialSegments + 1) + x;
+            int d = c + 1;
+
+            AddTriangle(indices, a, b, c);
+            AddTriangle(indices, b, d, c);
+        }
+    }
+
+    return std::make_shared<Mesh>(vertices, indices);
+}
+
+std::shared_ptr<Mesh> PrimitiveGenerator::CreateTriangle(float size)
+{
+    float halfSize = size * 0.5f;
+
+    std::vector<float> vertices = {
+        // Triangle vertices: position (3) + normal (3) + texcoord (2)
+        0.0f, halfSize, 0.0f, 0.0f, 0.0f, 1.0f, 0.5f, 1.0f,
+        -halfSize, -halfSize, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f,
+        halfSize, -halfSize, 0.0f, 0.0f, 0.0f, 1.0f, 1.0f, 0.0f};
+
+    std::vector<unsigned int> indices = {0, 1, 2};
+
+    return std::make_shared<Mesh>(vertices, indices);
+}
+
+void PrimitiveGenerator::AddVertex(std::vector<float> &vertices, float x, float y, float z,
+                                   float nx, float ny, float nz, float u, float v)
+{
+    vertices.push_back(x);
+    vertices.push_back(y);
+    vertices.push_back(z);
+    vertices.push_back(nx);
+    vertices.push_back(ny);
+    vertices.push_back(nz);
+    vertices.push_back(u);
+    vertices.push_back(v);
+}
+
+void PrimitiveGenerator::AddTriangle(std::vector<unsigned int> &indices, unsigned int a, unsigned int b, unsigned int c)
+{
+    indices.push_back(a);
+    indices.push_back(b);
+    indices.push_back(c);
+}

--- a/Engine/Scene/PrimitiveGenerator.h
+++ b/Engine/Scene/PrimitiveGenerator.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include "Graphics/Mesh.h"
+#include <memory>
+
+/**
+ * @class PrimitiveGenerator
+ * @brief Static utility class for generating primitive mesh shapes.
+ *
+ * PrimitiveGenerator provides methods to create common 3D primitive shapes
+ * such as cubes, spheres, planes, cylinders, etc. Each method returns a
+ * shared pointer to a Mesh object that can be used with scene objects.
+ */
+class PrimitiveGenerator
+{
+public:
+    /**
+     * @brief Creates a cube mesh.
+     * @param size The size of the cube (default: 1.0).
+     * @return Shared pointer to the cube mesh.
+     */
+    static std::shared_ptr<Mesh> CreateCube(float size = 1.0f);
+
+    /**
+     * @brief Creates a plane mesh.
+     * @param width The width of the plane (default: 1.0).
+     * @param height The height of the plane (default: 1.0).
+     * @param widthSegments Number of width segments (default: 1).
+     * @param heightSegments Number of height segments (default: 1).
+     * @return Shared pointer to the plane mesh.
+     */
+    static std::shared_ptr<Mesh> CreatePlane(float width = 1.0f, float height = 1.0f,
+                                             int widthSegments = 1, int heightSegments = 1);
+
+    /**
+     * @brief Creates a sphere mesh.
+     * @param radius The radius of the sphere (default: 0.5).
+     * @param widthSegments Number of horizontal segments (default: 32).
+     * @param heightSegments Number of vertical segments (default: 16).
+     * @return Shared pointer to the sphere mesh.
+     */
+    static std::shared_ptr<Mesh> CreateSphere(float radius = 0.5f, int widthSegments = 32, int heightSegments = 16);
+
+    /**
+     * @brief Creates a cylinder mesh.
+     * @param radiusTop The radius at the top (default: 0.5).
+     * @param radiusBottom The radius at the bottom (default: 0.5).
+     * @param height The height of the cylinder (default: 1.0).
+     * @param radialSegments Number of radial segments (default: 32).
+     * @param heightSegments Number of height segments (default: 1).
+     * @return Shared pointer to the cylinder mesh.
+     */
+    static std::shared_ptr<Mesh> CreateCylinder(float radiusTop = 0.5f, float radiusBottom = 0.5f,
+                                                float height = 1.0f, int radialSegments = 32, int heightSegments = 1);
+
+    /**
+     * @brief Creates a triangle mesh.
+     * @param size The size of the triangle (default: 1.0).
+     * @return Shared pointer to the triangle mesh.
+     */
+    static std::shared_ptr<Mesh> CreateTriangle(float size = 1.0f);
+
+private:
+    // Helper methods
+    static void AddVertex(std::vector<float> &vertices, float x, float y, float z, float nx, float ny, float nz, float u, float v);
+    static void AddTriangle(std::vector<unsigned int> &indices, unsigned int a, unsigned int b, unsigned int c);
+};

--- a/Engine/Scene/Scene.cpp
+++ b/Engine/Scene/Scene.cpp
@@ -1,0 +1,94 @@
+#include "Scene.h"
+#include <algorithm>
+
+Scene::Scene()
+{
+}
+
+Scene::~Scene()
+{
+    Clear();
+}
+
+SceneObject &Scene::AddObject(std::shared_ptr<SceneObject> object)
+{
+    m_Objects.push_back(object);
+    return *object;
+}
+
+SceneObject &Scene::AddObject(std::shared_ptr<Mesh> mesh, const std::string &name)
+{
+    auto object = std::make_shared<SceneObject>(mesh, name);
+    m_Objects.push_back(object);
+    return *object;
+}
+
+bool Scene::RemoveObject(const std::string &name)
+{
+    auto it = std::find_if(m_Objects.begin(), m_Objects.end(),
+                           [&name](const std::shared_ptr<SceneObject> &obj)
+                           {
+                               return obj->GetName() == name;
+                           });
+
+    if (it != m_Objects.end())
+    {
+        m_Objects.erase(it);
+        return true;
+    }
+    return false;
+}
+
+bool Scene::RemoveObject(std::shared_ptr<SceneObject> object)
+{
+    auto it = std::find(m_Objects.begin(), m_Objects.end(), object);
+    if (it != m_Objects.end())
+    {
+        m_Objects.erase(it);
+        return true;
+    }
+    return false;
+}
+
+std::shared_ptr<SceneObject> Scene::FindObject(const std::string &name) const
+{
+    auto it = std::find_if(m_Objects.begin(), m_Objects.end(),
+                           [&name](const std::shared_ptr<SceneObject> &obj)
+                           {
+                               return obj->GetName() == name;
+                           });
+
+    return (it != m_Objects.end()) ? *it : nullptr;
+}
+
+void Scene::Clear()
+{
+    m_Objects.clear();
+}
+
+void Scene::Update(float deltaTime)
+{
+    for (auto &object : m_Objects)
+    {
+        if (object)
+        {
+            object->Update(deltaTime);
+        }
+    }
+}
+
+void Scene::Render(Renderer &renderer, const Camera &camera, Shader &shader)
+{
+    for (auto &object : m_Objects)
+    {
+        if (object && object->IsVisible() && object->GetMesh())
+        {
+            // Call the object's pre-render hook
+            object->OnRender();
+
+            // Get the model matrix and render the object
+            Mat4 modelMatrix = object->GetModelMatrix();
+            renderer.Draw(*object->GetMesh(), shader, modelMatrix);
+        }
+    }
+}

--- a/Engine/Scene/Scene.h
+++ b/Engine/Scene/Scene.h
@@ -1,0 +1,100 @@
+#pragma once
+
+#include "SceneObject.h"
+#include "Graphics/Renderer.h"
+#include "Graphics/Camera.h"
+#include <vector>
+#include <memory>
+#include <string>
+
+/**
+ * @class Scene
+ * @brief Manages a collection of scene objects and provides rendering functionality.
+ *
+ * The Scene class is responsible for managing all objects in the 3D scene,
+ * providing methods to add, remove, and update objects. It also handles
+ * rendering all visible objects in the scene.
+ */
+class Scene
+{
+public:
+    /**
+     * @brief Constructor.
+     */
+    Scene();
+
+    /**
+     * @brief Destructor.
+     */
+    ~Scene();
+
+    /**
+     * @brief Adds a scene object to the scene.
+     * @param object Shared pointer to the scene object.
+     * @return Reference to the added object.
+     */
+    SceneObject &AddObject(std::shared_ptr<SceneObject> object);
+
+    /**
+     * @brief Creates and adds a scene object with a mesh.
+     * @param mesh Shared pointer to the mesh.
+     * @param name Name of the object.
+     * @return Reference to the created object.
+     */
+    SceneObject &AddObject(std::shared_ptr<Mesh> mesh, const std::string &name = "Object");
+
+    /**
+     * @brief Removes a scene object by name.
+     * @param name Name of the object to remove.
+     * @return True if object was found and removed, false otherwise.
+     */
+    bool RemoveObject(const std::string &name);
+
+    /**
+     * @brief Removes a scene object by pointer.
+     * @param object Shared pointer to the object to remove.
+     * @return True if object was found and removed, false otherwise.
+     */
+    bool RemoveObject(std::shared_ptr<SceneObject> object);
+
+    /**
+     * @brief Finds a scene object by name.
+     * @param name Name of the object to find.
+     * @return Shared pointer to the object, or nullptr if not found.
+     */
+    std::shared_ptr<SceneObject> FindObject(const std::string &name) const;
+
+    /**
+     * @brief Gets all scene objects.
+     * @return Vector of shared pointers to all objects.
+     */
+    const std::vector<std::shared_ptr<SceneObject>> &GetObjects() const { return m_Objects; }
+
+    /**
+     * @brief Clears all objects from the scene.
+     */
+    void Clear();
+
+    /**
+     * @brief Updates all objects in the scene.
+     * @param deltaTime Time since last update in seconds.
+     */
+    void Update(float deltaTime);
+
+    /**
+     * @brief Renders all visible objects in the scene.
+     * @param renderer Reference to the renderer.
+     * @param camera Reference to the camera.
+     * @param shader Reference to the shader.
+     */
+    void Render(Renderer &renderer, const Camera &camera, Shader &shader);
+
+    /**
+     * @brief Gets the number of objects in the scene.
+     * @return Number of objects.
+     */
+    size_t GetObjectCount() const { return m_Objects.size(); }
+
+private:
+    std::vector<std::shared_ptr<SceneObject>> m_Objects;
+};

--- a/Engine/Scene/SceneObject.cpp
+++ b/Engine/Scene/SceneObject.cpp
@@ -1,0 +1,11 @@
+#include "SceneObject.h"
+
+SceneObject::SceneObject(const std::string &name)
+    : m_Name(name), m_Transform(), m_Mesh(nullptr), m_Visible(true)
+{
+}
+
+SceneObject::SceneObject(std::shared_ptr<Mesh> mesh, const std::string &name)
+    : m_Name(name), m_Transform(), m_Mesh(mesh), m_Visible(true)
+{
+}

--- a/Engine/Scene/SceneObject.h
+++ b/Engine/Scene/SceneObject.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include "Math/Transform.h"
+#include "Graphics/Mesh.h"
+#include "Graphics/Shader.h"
+#include <memory>
+#include <string>
+
+/**
+ * @class SceneObject
+ * @brief Base class for objects in the 3D scene.
+ *
+ * SceneObject represents any object that can be placed in the 3D scene.
+ * It contains a transform for positioning, rotation, and scaling, as well as
+ * a mesh for rendering. This serves as the base class for all scene objects.
+ */
+class SceneObject
+{
+public:
+    /**
+     * @brief Constructor with name.
+     * @param name The name of the scene object.
+     */
+    explicit SceneObject(const std::string &name = "SceneObject");
+
+    /**
+     * @brief Constructor with mesh.
+     * @param mesh Shared pointer to the mesh.
+     * @param name The name of the scene object.
+     */
+    SceneObject(std::shared_ptr<Mesh> mesh, const std::string &name = "SceneObject");
+
+    /**
+     * @brief Virtual destructor.
+     */
+    virtual ~SceneObject() = default;
+
+    // Transform operations
+    Transform &GetTransform() { return m_Transform; }
+    const Transform &GetTransform() const { return m_Transform; }
+
+    // Mesh operations
+    void SetMesh(std::shared_ptr<Mesh> mesh) { m_Mesh = mesh; }
+    std::shared_ptr<Mesh> GetMesh() const { return m_Mesh; }
+
+    // Properties
+    const std::string &GetName() const { return m_Name; }
+    void SetName(const std::string &name) { m_Name = name; }
+
+    bool IsVisible() const { return m_Visible; }
+    void SetVisible(bool visible) { m_Visible = visible; }
+
+    /**
+     * @brief Gets the model matrix for rendering.
+     * @return The transformation matrix.
+     */
+    Mat4 GetModelMatrix() const { return m_Transform.GetMatrix(); }
+
+    /**
+     * @brief Virtual update method - can be overridden for custom behavior.
+     * @param deltaTime Time since last update in seconds.
+     */
+    virtual void Update(float deltaTime) {}
+
+    /**
+     * @brief Virtual method called before rendering - can be overridden.
+     */
+    virtual void OnRender() {}
+
+protected:
+    std::string m_Name;
+    Transform m_Transform;
+    std::shared_ptr<Mesh> m_Mesh;
+    bool m_Visible = true;
+};

--- a/Engine/Scene/SceneObjectFactory.cpp
+++ b/Engine/Scene/SceneObjectFactory.cpp
@@ -1,0 +1,35 @@
+#include "SceneObjectFactory.h"
+
+std::shared_ptr<SceneObject> SceneObjectFactory::CreateCube(const std::string &name, float size)
+{
+    auto mesh = PrimitiveGenerator::CreateCube(size);
+    return std::make_shared<SceneObject>(mesh, name);
+}
+
+std::shared_ptr<SceneObject> SceneObjectFactory::CreateSphere(const std::string &name, float radius,
+                                                              int widthSegments, int heightSegments)
+{
+    auto mesh = PrimitiveGenerator::CreateSphere(radius, widthSegments, heightSegments);
+    return std::make_shared<SceneObject>(mesh, name);
+}
+
+std::shared_ptr<SceneObject> SceneObjectFactory::CreatePlane(const std::string &name, float width, float height,
+                                                             int widthSegments, int heightSegments)
+{
+    auto mesh = PrimitiveGenerator::CreatePlane(width, height, widthSegments, heightSegments);
+    return std::make_shared<SceneObject>(mesh, name);
+}
+
+std::shared_ptr<SceneObject> SceneObjectFactory::CreateCylinder(const std::string &name, float radiusTop,
+                                                                float radiusBottom, float height,
+                                                                int radialSegments, int heightSegments)
+{
+    auto mesh = PrimitiveGenerator::CreateCylinder(radiusTop, radiusBottom, height, radialSegments, heightSegments);
+    return std::make_shared<SceneObject>(mesh, name);
+}
+
+std::shared_ptr<SceneObject> SceneObjectFactory::CreateTriangle(const std::string &name, float size)
+{
+    auto mesh = PrimitiveGenerator::CreateTriangle(size);
+    return std::make_shared<SceneObject>(mesh, name);
+}

--- a/Engine/Scene/SceneObjectFactory.cpp
+++ b/Engine/Scene/SceneObjectFactory.cpp
@@ -1,4 +1,7 @@
 #include "SceneObjectFactory.h"
+#include "../Loader/MeshLoader.h"
+#include <filesystem>
+#include <iostream>
 
 std::shared_ptr<SceneObject> SceneObjectFactory::CreateCube(const std::string &name, float size)
 {
@@ -31,5 +34,66 @@ std::shared_ptr<SceneObject> SceneObjectFactory::CreateCylinder(const std::strin
 std::shared_ptr<SceneObject> SceneObjectFactory::CreateTriangle(const std::string &name, float size)
 {
     auto mesh = PrimitiveGenerator::CreateTriangle(size);
+    return std::make_shared<SceneObject>(mesh, name);
+}
+
+std::shared_ptr<SceneObject> SceneObjectFactory::LoadFromFile(const std::string &filepath, const std::string &name)
+{
+    if (!std::filesystem::exists(filepath))
+    {
+        std::cerr << "File not found: " << filepath << std::endl;
+        return nullptr;
+    }
+
+    auto mesh = Engine::Loader::MeshLoader::LoadMesh(filepath);
+    if (!mesh)
+    {
+        std::cerr << "Failed to load mesh from: " << filepath << std::endl;
+        return nullptr;
+    }
+
+    std::string objectName = name.empty() ? std::filesystem::path(filepath).stem().string() : name;
+
+    return CreateFromMesh(mesh, objectName);
+}
+
+std::vector<std::shared_ptr<SceneObject>> SceneObjectFactory::LoadAllFromFile(const std::string &filepath)
+{
+    std::vector<std::shared_ptr<SceneObject>> objects;
+
+    if (!std::filesystem::exists(filepath))
+    {
+        std::cerr << "File not found: " << filepath << std::endl;
+        return objects;
+    }
+
+    auto meshes = Engine::Loader::MeshLoader::LoadMeshes(filepath);
+
+    for (size_t i = 0; i < meshes.size(); i++)
+    {
+        std::string objectName = std::filesystem::path(filepath).stem().string();
+        if (meshes.size() > 1)
+        {
+            objectName += "_" + std::to_string(i);
+        }
+
+        auto object = CreateFromMesh(meshes[i], objectName);
+        if (object)
+        {
+            objects.push_back(object);
+        }
+    }
+
+    return objects;
+}
+
+std::shared_ptr<SceneObject> SceneObjectFactory::CreateFromMesh(std::shared_ptr<Mesh> mesh, const std::string &name)
+{
+    if (!mesh)
+    {
+        std::cerr << "Cannot create scene object from null mesh" << std::endl;
+        return nullptr;
+    }
+
     return std::make_shared<SceneObject>(mesh, name);
 }

--- a/Engine/Scene/SceneObjectFactory.h
+++ b/Engine/Scene/SceneObjectFactory.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include "SceneObject.h"
+#include "PrimitiveGenerator.h"
+#include <memory>
+#include <string>
+
+/**
+ * @class SceneObjectFactory
+ * @brief Factory class for creating common scene objects with primitive meshes.
+ *
+ * SceneObjectFactory provides convenient methods to create scene objects
+ * with pre-generated primitive meshes, making it easy to add common shapes
+ * to the scene without manually creating meshes and objects.
+ */
+class SceneObjectFactory
+{
+public:
+    /**
+     * @brief Creates a cube scene object.
+     * @param name Name of the object.
+     * @param size Size of the cube.
+     * @return Shared pointer to the created scene object.
+     */
+    static std::shared_ptr<SceneObject> CreateCube(const std::string &name = "Cube", float size = 1.0f);
+
+    /**
+     * @brief Creates a sphere scene object.
+     * @param name Name of the object.
+     * @param radius Radius of the sphere.
+     * @param widthSegments Number of horizontal segments.
+     * @param heightSegments Number of vertical segments.
+     * @return Shared pointer to the created scene object.
+     */
+    static std::shared_ptr<SceneObject> CreateSphere(const std::string &name = "Sphere", float radius = 0.5f,
+                                                     int widthSegments = 32, int heightSegments = 16);
+
+    /**
+     * @brief Creates a plane scene object.
+     * @param name Name of the object.
+     * @param width Width of the plane.
+     * @param height Height of the plane.
+     * @param widthSegments Number of width segments.
+     * @param heightSegments Number of height segments.
+     * @return Shared pointer to the created scene object.
+     */
+    static std::shared_ptr<SceneObject> CreatePlane(const std::string &name = "Plane", float width = 1.0f,
+                                                    float height = 1.0f, int widthSegments = 1, int heightSegments = 1);
+
+    /**
+     * @brief Creates a cylinder scene object.
+     * @param name Name of the object.
+     * @param radiusTop Radius at the top.
+     * @param radiusBottom Radius at the bottom.
+     * @param height Height of the cylinder.
+     * @param radialSegments Number of radial segments.
+     * @param heightSegments Number of height segments.
+     * @return Shared pointer to the created scene object.
+     */
+    static std::shared_ptr<SceneObject> CreateCylinder(const std::string &name = "Cylinder", float radiusTop = 0.5f,
+                                                       float radiusBottom = 0.5f, float height = 1.0f,
+                                                       int radialSegments = 32, int heightSegments = 1);
+
+    /**
+     * @brief Creates a triangle scene object.
+     * @param name Name of the object.
+     * @param size Size of the triangle.
+     * @return Shared pointer to the created scene object.
+     */
+    static std::shared_ptr<SceneObject> CreateTriangle(const std::string &name = "Triangle", float size = 1.0f);
+};

--- a/Engine/Scene/SceneObjectFactory.h
+++ b/Engine/Scene/SceneObjectFactory.h
@@ -59,13 +59,34 @@ public:
      */
     static std::shared_ptr<SceneObject> CreateCylinder(const std::string &name = "Cylinder", float radiusTop = 0.5f,
                                                        float radiusBottom = 0.5f, float height = 1.0f,
-                                                       int radialSegments = 32, int heightSegments = 1);
+                                                       int radialSegments = 32, int heightSegments = 1); /**
+                                                                                                          * @brief Creates a triangle scene object.
+                                                                                                          * @param name Name of the object.
+                                                                                                          * @param size Size of the triangle.
+                                                                                                          * @return Shared pointer to the created scene object.
+                                                                                                          */
+    static std::shared_ptr<SceneObject> CreateTriangle(const std::string &name = "Triangle", float size = 1.0f);
 
     /**
-     * @brief Creates a triangle scene object.
+     * @brief Load a scene object from an external mesh file (OBJ, FBX, etc.).
+     * @param filepath Path to the mesh file.
+     * @param name Name of the object (defaults to filename if empty).
+     * @return Shared pointer to the created scene object, or nullptr if failed.
+     */
+    static std::shared_ptr<SceneObject> LoadFromFile(const std::string &filepath, const std::string &name = "");
+
+    /**
+     * @brief Load all meshes from a file as separate scene objects.
+     * @param filepath Path to the mesh file.
+     * @return Vector of shared pointers to all created scene objects.
+     */
+    static std::vector<std::shared_ptr<SceneObject>> LoadAllFromFile(const std::string &filepath);
+
+    /**
+     * @brief Create a scene object from an existing mesh.
+     * @param mesh Shared pointer to the mesh.
      * @param name Name of the object.
-     * @param size Size of the triangle.
      * @return Shared pointer to the created scene object.
      */
-    static std::shared_ptr<SceneObject> CreateTriangle(const std::string &name = "Triangle", float size = 1.0f);
+    static std::shared_ptr<SceneObject> CreateFromMesh(std::shared_ptr<Mesh> mesh, const std::string &name = "CustomMesh");
 };

--- a/Shaders/default.frag
+++ b/Shaders/default.frag
@@ -1,0 +1,20 @@
+#version 460 core
+
+in vec3 v_Normal;
+in vec2 v_TexCoord;
+in vec3 v_WorldPos;
+
+out vec4 FragColor;
+
+void main() {
+    // Simple lighting calculation
+    vec3 lightDir = normalize(vec3(1.0, 1.0, 1.0));
+    vec3 normal = normalize(v_Normal);
+    float diff = max(dot(normal, lightDir), 0.0);
+
+    // Base color with simple diffuse lighting
+    vec3 baseColor = vec3(0.8, 0.6, 0.4);
+    vec3 color = baseColor * (0.3 + 0.7 * diff); // ambient + diffuse
+
+    FragColor = vec4(color, 1.0);
+}

--- a/Shaders/default.vert
+++ b/Shaders/default.vert
@@ -1,0 +1,21 @@
+#version 460 core
+
+layout(location = 0) in vec3 aPos;
+layout(location = 1) in vec3 aNormal;
+layout(location = 2) in vec2 aTexCoord;
+
+uniform mat4 u_Model;
+uniform mat4 u_ViewProjection;
+
+out vec3 v_Normal;
+out vec2 v_TexCoord;
+out vec3 v_WorldPos;
+
+void main() {
+    vec4 worldPos = u_Model * vec4(aPos, 1.0);
+    v_WorldPos = worldPos.xyz;
+    v_Normal = mat3(u_Model) * aNormal; // Simple normal transformation (not correct for non-uniform scaling)
+    v_TexCoord = aTexCoord;
+
+    gl_Position = u_ViewProjection * worldPos;
+}

--- a/Shaders/simple.frag
+++ b/Shaders/simple.frag
@@ -1,6 +1,0 @@
-#version 460 core
-out vec4 FragColor;
-
-void main() {
-    FragColor = vec4(1.0, 0.4, 0.2, 1.0);
-}

--- a/Shaders/simple.vert
+++ b/Shaders/simple.vert
@@ -1,8 +1,0 @@
-#version 460 core
-
-layout(location = 0) in vec3 aPos;
-uniform mat4 u_ViewProjection;
-
-void main() {
-    gl_Position = u_ViewProjection * vec4(aPos, 1.0);
-}


### PR DESCRIPTION
- Updated Viewport component to include Scene management.
- Added new Mesh constructor to support std::vector for vertices and indices.
- Enhanced Renderer class to support model transformation matrices during drawing.
- Removed deprecated shader files and replaced them with new default shaders.
- Implemented Transform class for handling 3D transformations (position, rotation, scale).
- Created PrimitiveGenerator for generating common 3D shapes (cube, sphere, plane, cylinder, triangle).
- Developed Scene and SceneObject classes for managing and rendering scene objects.
- Introduced SceneObjectFactory for convenient creation of scene objects with primitive meshes.
- Updated documentation for clarity and completeness across various classes and methods.