### PR TITLE
#11: Add automated testing and static analysis

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,29 @@
+---
+Language: Cpp
+BasedOnStyle: LLVM
+Standard: c++17
+
+# Enforce some basic rules mentioned in the code style
+# Or just use the defaults of LLVM which are widely accepted for C++
+UseTab: Never
+IndentWidth: 4
+TabWidth: 4
+ColumnLimit: 120
+
+# Pointer Alignment
+PointerAlignment: Left
+
+# Braces
+BreakBeforeBraces: Attach
+
+# Spaces
+SpaceBeforeParens: ControlStatements
+SpaceAfterCStyleCast: true
+
+# Access Modifiers
+AccessModifierOffset: -4
+
+# Include Blocks
+IncludeBlocks: Regroup
+
+...

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,30 @@
+---
+Checks: >
+  -*,
+  bugprone-*,
+  readability-*,
+  -readability-braces-around-statements,
+  -readability-magic-numbers,
+  modernize-*,
+  -modernize-use-trailing-return-type
+
+WarningsAsErrors: ''
+HeaderFilterRegex: '.*'
+FormatStyle: file
+
+CheckOptions:
+  - key:             readability-identifier-naming.ClassCase
+    value:           PascalCase
+  - key:             readability-identifier-naming.StructCase
+    value:           PascalCase
+  - key:             readability-identifier-naming.FunctionCase
+    value:           PascalCase
+  - key:             readability-identifier-naming.VariableCase
+    value:           camelBack
+  - key:             readability-identifier-naming.GlobalConstantCase
+    value:           UPPER_CASE
+  - key:             readability-identifier-naming.MemberPrefix
+    value:           'm_'
+  - key:             readability-identifier-naming.MemberCase
+    value:           camelBack
+...

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,10 @@ jobs:
     - name: Build
       run: cmake --build ${{ env.BUILD_DIR }} --config ${{ env.BUILD_TYPE }}
 
+    - name: Test
+      working-directory: ${{ env.BUILD_DIR }}
+      run: ctest -C ${{ env.BUILD_TYPE }} --output-on-failure
+
     - name: Create package
       working-directory: ${{ env.BUILD_DIR }}
       shell: cmd
@@ -80,6 +84,10 @@ jobs:
     - name: Build
       run: cmake --build ${{ env.BUILD_DIR }} --config ${{ env.BUILD_TYPE }} -j4
 
+    - name: Test
+      working-directory: ${{ env.BUILD_DIR }}
+      run: ctest -C ${{ env.BUILD_TYPE }} --output-on-failure
+
     - name: Create package
       working-directory: ${{ env.BUILD_DIR }}
       run: |
@@ -120,6 +128,10 @@ jobs:
     - name: Build
       run: cmake --build ${{ env.BUILD_DIR }} --config ${{ env.BUILD_TYPE }} -j$(nproc)
 
+    - name: Test
+      working-directory: ${{ env.BUILD_DIR }}
+      run: ctest -C ${{ env.BUILD_TYPE }} --output-on-failure
+
     - name: Create package
       working-directory: ${{ env.BUILD_DIR }}
       run: |
@@ -132,6 +144,27 @@ jobs:
       with:
         name: Voltray-Linux
         path: ${{ env.BUILD_DIR }}/Voltray-linux.tar.gz
+
+  static-analysis:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y clang-format clang-tidy cmake
+
+    - name: Check Code Formatting (clang-format)
+      run: |
+        find . \( -name "*.h" -o -name "*.cpp" \) -not -path "./Vendor/*" -not -path "./build/*" | xargs clang-format --dry-run -Werror
+
+    - name: Configure CMake for Static Analysis
+      run: cmake -B ${{ env.BUILD_DIR }} -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+
+    - name: Run Static Analysis (clang-tidy)
+      run: |
+        find . \( -name "*.h" -o -name "*.cpp" \) -not -path "./Vendor/*" -not -path "./build/*" | xargs clang-tidy -p ${{ env.BUILD_DIR }}
 
   release:
     if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,7 +153,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y clang-format clang-tidy cmake
+        sudo apt-get install -y cmake build-essential xorg-dev libgl1-mesa-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev clang-format clang-tidy
 
     - name: Check Code Formatting (clang-format)
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Voltray CI/CD
 
 on:
   push:
-    branches: [ main, master, develop ]
+    branches: [ main, master, dev ]
   pull_request:
-    branches: [ main, master, develop ]
+    branches: [ main, master, dev ]
   workflow_dispatch:  # Allows manual triggering
 
 env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -157,14 +157,14 @@ jobs:
 
     - name: Check Code Formatting (clang-format)
       run: |
-        find . \( -name "*.h" -o -name "*.cpp" \) -not -path "./Vendor/*" -not -path "./build/*" | xargs clang-format --dry-run -Werror
+        find . \( -name "*.h" -o -name "*.cpp" \) -not -path "./Vendor/*" -not -path "./build/*" -print0 | xargs -0 -r clang-format --dry-run -Werror
 
     - name: Configure CMake for Static Analysis
       run: cmake -B ${{ env.BUILD_DIR }} -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
     - name: Run Static Analysis (clang-tidy)
       run: |
-        find . \( -name "*.h" -o -name "*.cpp" \) -not -path "./Vendor/*" -not -path "./build/*" | xargs clang-tidy -p ${{ env.BUILD_DIR }}
+        find . \( -name "*.h" -o -name "*.cpp" \) -not -path "./Vendor/*" -not -path "./build/*" -print0 | xargs -0 -r clang-tidy -p ${{ env.BUILD_DIR }}
 
   release:
     if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,7 +168,7 @@ jobs:
 
   release:
     if: startsWith(github.ref, 'refs/tags/')
-    needs: [windows-build, macos-build, linux-build]
+    needs: [windows-build, macos-build, linux-build, static-analysis]
     runs-on: ubuntu-latest
     steps:
       - name: Download Windows artifact

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,9 @@ project(Voltray)
 
 set(CMAKE_CXX_STANDARD 17)
 
+# Enable CTest framework for automated testing
+enable_testing()
+
 # Prevent GLFW from using Wayland
 set(GLFW_BUILD_WAYLAND OFF)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,9 @@ set(CMAKE_CXX_STANDARD 17)
 # Enable CTest framework for automated testing
 enable_testing()
 
+# Basic CTest smoke test to verify testing infrastructure
+add_test(NAME VoltrayCTestSmoke
+         COMMAND ${CMAKE_COMMAND} -E echo "Voltray CTest infrastructure is working")
 # Prevent GLFW from using Wayland
 set(GLFW_BUILD_WAYLAND OFF)
 


### PR DESCRIPTION
Resolves #11

**Changes:**
- Added [.clang-format](cci:7://file:///c:/Github/Voltray/.clang-format:0:0-0:0) based on LLVM C++17 style.
- Added [.clang-tidy](cci:7://file:///c:/Github/Voltray/.clang-tidy:0:0-0:0) configuration.
- Updated [build.yml](cci:7://file:///c:/Github/Voltray/.github/workflows/build.yml:0:0-0:0) CI workflow:
  - Added `ctest` step to Windows, macOS, and Linux builds.
  - Added new `static-analysis` job (`clang-format` and `clang-tidy`).
